### PR TITLE
fix: improve launch scripts

### DIFF
--- a/launchers/ios/run-ios-sim.sh
+++ b/launchers/ios/run-ios-sim.sh
@@ -1,10 +1,10 @@
-#/bin/bash
+#!/bin/bash
 set -e
 
 TARGET="${TARGET:-x86_64-apple-ios}"
 which dasel || brew install dasel
-APP_NAME="$(cat Cargo.toml | dasel -r toml '.package.name')"
-BUNDLE_ID="$(cat Cargo.toml | dasel -r toml '.package.metadata.bundle.identifier')"
+APP_NAME="$(dasel -f Cargo.toml '.package.name')"
+BUNDLE_ID="$(dasel -f Cargo.toml '.package.metadata.bundle.identifier')"
 
 BUNDLE_CMD="cargo bundle --target $TARGET"
 

--- a/launchers/native/run-native.sh
+++ b/launchers/native/run-native.sh
@@ -1,9 +1,9 @@
-#/bin/bash
+#!/bin/bash
 set -e
 
 echo "Copying assets"
 if [ ! -d ../../assets ]; then
-    echo "Error: work dir must be iOS launcher directory before running this script"
+    echo "Error: work dir must be native launcher directory before running this script"
     exit 1
 fi
 cp -r ../../assets/ assets/


### PR DESCRIPTION
This PR fixes the shebangs, fixes a typo, and prefers using `dasel`'s `-f` option over `cat |` in the 
launch scripts
